### PR TITLE
fix: 保持ngbatis-demo代码和doc文档一致

### DIFF
--- a/docs/docs/v1.1.0-rc/en/md/dev-example/prepare.md
+++ b/docs/docs/v1.1.0-rc/en/md/dev-example/prepare.md
@@ -16,6 +16,7 @@ Take  `Person` 与 `Like` as examples.
 CREATE tag `person` (
   `name` string NULL  , 
   `gender` string NULL  , 
+  `height` double NULL ,
   `age` int NULL  , 
   `birthday` date NULL  
 );
@@ -47,6 +48,8 @@ public class Person {
     @Id
     private String name;
     private String gender;
+    @ValueType(Double.class)
+    private BigDecimal height;
     private Integer age;
     private Date birthday;
 }

--- a/docs/docs/v1.1.0-rc/zhCn/md/dev-example/prepare.md
+++ b/docs/docs/v1.1.0-rc/zhCn/md/dev-example/prepare.md
@@ -16,6 +16,7 @@ Ngbatis 提供了两种方式为开发者提供便利
 CREATE tag `person` (
   `name` string NULL  , 
   `gender` string NULL  , 
+  `height` double NULL ,
   `age` int NULL  , 
   `birthday` date NULL  
 );
@@ -51,6 +52,8 @@ public class Person {
     /** use @Column to declare field's schema name in database */
     @Column("gender")
     private String gender;
+    @ValueType(Double.class)
+    private BigDecimal height;
     private Integer age;
     private Date birthday;
 


### PR DESCRIPTION
背景：按照文档中的person tag语句创建后，运行ngbatis-demo的测试用例时会报错，提示找不到height。
需要再次执行：ALTER TAG person add (height double);  才可以运行正常；
所以这里做个补充，ngbatis-demo代码和doc文档一致会不会更好一些呢？
